### PR TITLE
Allow debug logging using `debug` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "bath": "^3.0.1",
+        "debug": "^4.3.4",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@jest/types": "^29.0.3",
         "@types/aws-lambda": "^8.10.104",
+        "@types/debug": "^4.1.7",
         "@types/jest": "^27.4.0",
         "@types/json-schema": "^7.0.6",
         "@types/node": "^18.7.18",
@@ -1505,6 +1507,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1558,6 +1569,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2659,7 +2676,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6077,8 +6093,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -9069,6 +9084,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -9122,6 +9146,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -9931,7 +9961,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -12572,8 +12601,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "bath": "^3.0.1",
+    "debug": "^4.3.4",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@jest/types": "^29.0.3",
     "@types/aws-lambda": "^8.10.104",
+    "@types/debug": "^4.1.7",
     "@types/jest": "^27.4.0",
     "@types/json-schema": "^7.0.6",
     "@types/node": "^18.7.18",

--- a/src/openapi-lambda-adapters.ts
+++ b/src/openapi-lambda-adapters.ts
@@ -2,12 +2,17 @@ import {
   APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2,
   APIGatewayProxyEventQueryStringParameters, APIGatewayProxyEventPathParameters
 } from 'aws-lambda'
+
+import createDebug from 'debug'
+
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 import type { Runner, Operation, UnknownContext } from 'openapi-client-axios'
 import { invokeLambda } from './lambda-invoker'
 import { params } from 'bath/params'
 import { safeParseJson } from './util'
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from 'uuid'
+
+const debug = createDebug('openapi-lambda-adapter')
 
 export const getLambdaRunner = (functionName: string): Runner => {
   return {
@@ -53,7 +58,7 @@ export const convertAxiosToApiGw = (config: AxiosRequestConfig, operation: Opera
   const urlSearchParams = new URLSearchParams()
   Object.entries(config.params ?? {}).forEach(([key, val]) => urlSearchParams.append(key, val.toString()))
 
-  return {
+  const lambdaPayload = {
     version: '2.0',
     routeKey: '$default',
     rawPath: config.url,
@@ -88,9 +93,15 @@ export const convertAxiosToApiGw = (config: AxiosRequestConfig, operation: Opera
     isBase64Encoded: false,
     httpMethod: config.method
   } as APIGatewayProxyEventV2
+
+  debug('lambdaRequest %o', lambdaPayload)
+
+  return lambdaPayload
 }
 
 export const convertApiGwToAxios = (resp: APIGatewayProxyStructuredResultV2, axiosConfig: AxiosRequestConfig) => {
+  debug('lambdaResponse %o', resp)
+
   const axiosResp = {
     config: axiosConfig,
     status: resp.statusCode,
@@ -113,7 +124,7 @@ class AxiosError extends Error {
   public readonly response: AxiosResponse
   public readonly isAxiosError: boolean
 
-  constructor(message: string, code: string, response: AxiosResponse) {
+  constructor (message: string, code: string, response: AxiosResponse) {
     super(message)
 
     this.message = message
@@ -127,7 +138,7 @@ class AxiosError extends Error {
     response?.request && (this.request = response.request)
   }
 
-  public toJSON() {
+  public toJSON () {
     return {
       // Standard
       message: this.message,


### PR DESCRIPTION
This change allows easily setting up debug logs with `DEBUG=*` or `DEBUG=openapi-lambda-adapter` environment variables.