### PR TITLE
Fix/stringify headers

### DIFF
--- a/src/openapi-lambda-adapters.test.ts
+++ b/src/openapi-lambda-adapters.test.ts
@@ -141,6 +141,39 @@ describe('Adapt axios request/response to AWS Lambda Proxy Event/Response', () =
       })
       expect(event.rawQueryString).toEqual('colors=red&colors=blue&number=0&boolean=false')
     })
+
+    it('converts axios call with non-string headers', () => {
+      // given
+      const axiosConfig: AxiosRequestConfig = {
+        method: 'get',
+        url: '/v1/users',
+        headers: {
+          'x-boolean': true,
+          'x-number': 100,
+          'x-object': {
+            key: 'value'
+          },
+          'x-array': ['a', 'b'],
+          'x-null': null,
+          'x-string': 'string'
+        } as unknown as Record<string, string>
+      }
+      const operation: Operation = {
+        path: '/v1/users',
+        method: HttpMethod.Get,
+        responses: {}
+      }
+
+      // then
+      const event = convertAxiosToApiGw(axiosConfig, operation)
+      
+      expect(event.headers['x-boolean']).toBe('true')
+      expect(event.headers['x-number']).toBe('100')
+      expect(event.headers['x-string']).toBe('string')
+      expect(event.headers['x-object']).toBe('[object Object]')
+      expect(event.headers['x-array']).toBe('a,b')
+      expect(event.headers['x-null']).toBeUndefined()
+    })
   })
 
   describe('Api GW Proxy Response to Axios Response', () => {

--- a/src/openapi-lambda-adapters.test.ts
+++ b/src/openapi-lambda-adapters.test.ts
@@ -150,11 +150,13 @@ describe('Adapt axios request/response to AWS Lambda Proxy Event/Response', () =
         headers: {
           'x-boolean': true,
           'x-number': 100,
+          'x-zero': 0,
           'x-object': {
             key: 'value'
           },
           'x-array': ['a', 'b'],
           'x-null': null,
+          'x-undefined': undefined,
           'x-string': 'string'
         } as unknown as Record<string, string>
       }
@@ -169,10 +171,12 @@ describe('Adapt axios request/response to AWS Lambda Proxy Event/Response', () =
       
       expect(event.headers['x-boolean']).toBe('true')
       expect(event.headers['x-number']).toBe('100')
+      expect(event.headers['x-zero']).toBe('0')
       expect(event.headers['x-string']).toBe('string')
       expect(event.headers['x-object']).toBe('[object Object]')
       expect(event.headers['x-array']).toBe('a,b')
       expect(event.headers['x-null']).toBeUndefined()
+      expect(event.headers['x-undefined']).toBeUndefined()
     })
   })
 

--- a/src/openapi-lambda-adapters.ts
+++ b/src/openapi-lambda-adapters.ts
@@ -54,7 +54,7 @@ export const convertAxiosToApiGw = (config: AxiosRequestConfig, operation: Opera
   Object.entries(config.params ?? {}).forEach(([key, val]) => urlSearchParams.append(key, val.toString()))
 
   const headers: Record<string, string> = {}
-  for (const [key, val] of Object.entries(config.headers ?? {}).filter(([_key, val]) => val !== null)) {
+  for (const [key, val] of Object.entries(config.headers ?? {}).filter(([_key, val]) => val !== null && val !== undefined)) {
     headers[key] = val.toString()
   }
 

--- a/src/openapi-lambda-adapters.ts
+++ b/src/openapi-lambda-adapters.ts
@@ -7,7 +7,7 @@ import type { Runner, Operation, UnknownContext } from 'openapi-client-axios'
 import { invokeLambda } from './lambda-invoker'
 import { params } from 'bath/params'
 import { safeParseJson } from './util'
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from 'uuid'
 
 export const getLambdaRunner = (functionName: string): Runner => {
   return {
@@ -53,11 +53,16 @@ export const convertAxiosToApiGw = (config: AxiosRequestConfig, operation: Opera
   const urlSearchParams = new URLSearchParams()
   Object.entries(config.params ?? {}).forEach(([key, val]) => urlSearchParams.append(key, val.toString()))
 
+  const headers: Record<string, string> = {}
+  for (const [key, val] of Object.entries(config.headers ?? {}).filter(([_key, val]) => val !== null)) {
+    headers[key] = val.toString()
+  }
+
   return {
     version: '2.0',
     routeKey: '$default',
     rawPath: config.url,
-    headers: { ...(config.headers ?? {}) },
+    headers,
     queryStringParameters: queryParams,
     rawQueryString: queryString.join('&'),
     pathParameters: pathParams,
@@ -113,7 +118,7 @@ class AxiosError extends Error {
   public readonly response: AxiosResponse
   public readonly isAxiosError: boolean
 
-  constructor(message: string, code: string, response: AxiosResponse) {
+  constructor (message: string, code: string, response: AxiosResponse) {
     super(message)
 
     this.message = message
@@ -127,7 +132,7 @@ class AxiosError extends Error {
     response?.request && (this.request = response.request)
   }
 
-  public toJSON() {
+  public toJSON () {
     return {
       // Standard
       message: this.message,


### PR DESCRIPTION
When header values are present (not undefined and null) stringify them, to avoid passing numbers and booleans over.